### PR TITLE
Discard master/slave language

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -53,8 +53,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'nova'

--- a/nova/api/openstack/compute/contrib/extended_host_ip.py
+++ b/nova/api/openstack/compute/contrib/extended_host_ip.py
@@ -32,7 +32,7 @@ class ExtendedHostIpController(wsgi.Controller):
     def show(self, req, resp_obj, id):
         context = req.environ['nova.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             # resp_obj.attach(xml=ExtendedStatusTemplate())
             server = resp_obj.obj['server']
             db_instance = req.get_db_instance(server['id'])

--- a/nova/api/openstack/compute/contrib/extended_server_attributes.py
+++ b/nova/api/openstack/compute/contrib/extended_server_attributes.py
@@ -75,7 +75,7 @@ class ExtendedServerAttributesController(wsgi.Controller):
     def show(self, req, resp_obj, id):
         context = req.environ['nova.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=ExtendedServerAttributeTemplate())
             server = resp_obj.obj['server']
             db_instance = req.get_db_instance(server['id'])
@@ -89,7 +89,7 @@ class ExtendedServerAttributesController(wsgi.Controller):
         list_optimization = params.get('list_optimization')
         context = req.environ['nova.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=ExtendedServerAttributesTemplate())
 
             servers = list(resp_obj.obj['servers'])
@@ -136,7 +136,7 @@ class ExtendedServerAttributeTemplate(xmlutil.TemplateBuilder):
         make_server(root)
         alias = Extended_server_attributes.alias
         namespace = Extended_server_attributes.namespace
-        return xmlutil.SlaveTemplate(root, 1, nsmap={alias: namespace})
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={alias: namespace})
 
 
 class ExtendedServerAttributesTemplate(xmlutil.TemplateBuilder):
@@ -146,4 +146,4 @@ class ExtendedServerAttributesTemplate(xmlutil.TemplateBuilder):
         make_server(elem)
         alias = Extended_server_attributes.alias
         namespace = Extended_server_attributes.namespace
-        return xmlutil.SlaveTemplate(root, 1, nsmap={alias: namespace})
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={alias: namespace})

--- a/nova/api/openstack/compute/contrib/extended_status.py
+++ b/nova/api/openstack/compute/contrib/extended_status.py
@@ -41,7 +41,7 @@ class ExtendedStatusController(wsgi.Controller):
     def show(self, req, resp_obj, id):
         context = req.environ['nova.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=ExtendedStatusTemplate())
             server = resp_obj.obj['server']
             db_instance = req.get_db_instance(server['id'])
@@ -53,7 +53,7 @@ class ExtendedStatusController(wsgi.Controller):
     def detail(self, req, resp_obj):
         context = req.environ['nova.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=ExtendedStatusesTemplate())
             servers = list(resp_obj.obj['servers'])
             for server in servers:
@@ -91,7 +91,7 @@ class ExtendedStatusTemplate(xmlutil.TemplateBuilder):
     def construct(self):
         root = xmlutil.TemplateElement('server', selector='server')
         make_server(root)
-        return xmlutil.SlaveTemplate(root, 1, nsmap={
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={
             Extended_status.alias: Extended_status.namespace})
 
 
@@ -100,5 +100,5 @@ class ExtendedStatusesTemplate(xmlutil.TemplateBuilder):
         root = xmlutil.TemplateElement('servers')
         elem = xmlutil.SubTemplateElement(root, 'server', selector='servers')
         make_server(elem)
-        return xmlutil.SlaveTemplate(root, 1, nsmap={
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={
             Extended_status.alias: Extended_status.namespace})

--- a/nova/api/openstack/compute/contrib/flavor_access.py
+++ b/nova/api/openstack/compute/contrib/flavor_access.py
@@ -45,7 +45,7 @@ class FlavorextradatumTemplate(xmlutil.TemplateBuilder):
         make_flavor(root)
         alias = Flavor_access.alias
         namespace = Flavor_access.namespace
-        return xmlutil.SlaveTemplate(root, 1, nsmap={alias: namespace})
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={alias: namespace})
 
 
 class FlavorextradataTemplate(xmlutil.TemplateBuilder):
@@ -55,7 +55,7 @@ class FlavorextradataTemplate(xmlutil.TemplateBuilder):
         make_flavor(elem)
         alias = Flavor_access.alias
         namespace = Flavor_access.namespace
-        return xmlutil.SlaveTemplate(root, 1, nsmap={alias: namespace})
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={alias: namespace})
 
 
 class FlavorAccessTemplate(xmlutil.TemplateBuilder):
@@ -68,7 +68,7 @@ class FlavorAccessTemplate(xmlutil.TemplateBuilder):
         elem = xmlutil.SubTemplateElement(root, 'access',
                                           selector='flavor_access')
         make_flavor_access(elem)
-        return xmlutil.MasterTemplate(root, 1)
+        return xmlutil.MainTemplate(root, 1)
 
 
 def _marshall_flavor_access(flavor_id):
@@ -137,7 +137,7 @@ class FlavorActionController(wsgi.Controller):
     def show(self, req, resp_obj, id):
         context = req.environ['nova.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=FlavorextradatumTemplate())
             db_flavor = req.get_db_flavor(id)
 
@@ -147,7 +147,7 @@ class FlavorActionController(wsgi.Controller):
     def detail(self, req, resp_obj):
         context = req.environ['nova.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=FlavorextradataTemplate())
 
             flavors = list(resp_obj.obj['flavors'])
@@ -159,7 +159,7 @@ class FlavorActionController(wsgi.Controller):
     def create(self, req, body, resp_obj):
         context = req.environ['nova.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=FlavorextradatumTemplate())
 
             db_flavor = req.get_db_flavor(resp_obj.obj['flavor']['id'])

--- a/nova/api/openstack/compute/servers.py
+++ b/nova/api/openstack/compute/servers.py
@@ -96,7 +96,7 @@ class ServerTemplate(xmlutil.TemplateBuilder):
     def construct(self):
         root = xmlutil.TemplateElement('server', selector='server')
         make_server(root, detailed=True)
-        return xmlutil.MasterTemplate(root, 1, nsmap=server_nsmap)
+        return xmlutil.MainTemplate(root, 1, nsmap=server_nsmap)
 
 
 class MinimalServersTemplate(xmlutil.TemplateBuilder):
@@ -105,7 +105,7 @@ class MinimalServersTemplate(xmlutil.TemplateBuilder):
         elem = xmlutil.SubTemplateElement(root, 'server', selector='servers')
         make_server(elem)
         xmlutil.make_links(root, 'servers_links')
-        return xmlutil.MasterTemplate(root, 1, nsmap=server_nsmap)
+        return xmlutil.MainTemplate(root, 1, nsmap=server_nsmap)
 
 
 class ServersTemplate(xmlutil.TemplateBuilder):
@@ -113,20 +113,20 @@ class ServersTemplate(xmlutil.TemplateBuilder):
         root = xmlutil.TemplateElement('servers')
         elem = xmlutil.SubTemplateElement(root, 'server', selector='servers')
         make_server(elem, detailed=True)
-        return xmlutil.MasterTemplate(root, 1, nsmap=server_nsmap)
+        return xmlutil.MainTemplate(root, 1, nsmap=server_nsmap)
 
 
 class ServerAdminPassTemplate(xmlutil.TemplateBuilder):
     def construct(self):
         root = xmlutil.TemplateElement('server')
         root.set('adminPass')
-        return xmlutil.SlaveTemplate(root, 1, nsmap=server_nsmap)
+        return xmlutil.SubordinateTemplate(root, 1, nsmap=server_nsmap)
 
 
 def FullServerTemplate():
-    master = ServerTemplate()
-    master.attach(ServerAdminPassTemplate())
-    return master
+    main = ServerTemplate()
+    main.attach(ServerAdminPassTemplate())
+    return main
 
 
 class CommonDeserializer(wsgi.MetadataXMLDeserializer):

--- a/nova/api/openstack/wsgi.py
+++ b/nova/api/openstack/wsgi.py
@@ -559,7 +559,7 @@ class ResponseObject(object):
         self.serializer = serializer()
 
     def attach(self, **kwargs):
-        """Attach slave templates to serializers."""
+        """Attach subordinate templates to serializers."""
 
         if self.media_type in kwargs:
             self.serializer.attach(kwargs[self.media_type])

--- a/nova/api/openstack/xmlutil.py
+++ b/nova/api/openstack/xmlutil.py
@@ -641,13 +641,13 @@ class Template(object):
         # We are a template
         return self
 
-    def apply(self, master):
-        """Hook method for determining slave applicability.
+    def apply(self, main):
+        """Hook method for determining subordinate applicability.
 
         An overridable hook method used to determine if this template
-        is applicable as a slave to a given master template.
+        is applicable as a subordinate to a given main template.
 
-        :param master: The master template to test.
+        :param main: The main template to test.
         """
 
         return True
@@ -662,17 +662,17 @@ class Template(object):
         return "%r: %s" % (self, self.root.tree())
 
 
-class MasterTemplate(Template):
-    """Represent a master template.
+class MainTemplate(Template):
+    """Represent a main template.
 
-    Master templates are versioned derivatives of templates that
-    additionally allow slave templates to be attached.  Slave
+    Main templates are versioned derivatives of templates that
+    additionally allow subordinate templates to be attached.  Subordinate
     templates allow modification of the serialized result without
-    directly changing the master.
+    directly changing the main.
     """
 
     def __init__(self, root, version, nsmap=None):
-        """Initialize a master template.
+        """Initialize a main template.
 
         :param root: The root element of the template.
         :param version: The version number of the template.
@@ -681,9 +681,9 @@ class MasterTemplate(Template):
                       template.
         """
 
-        super(MasterTemplate, self).__init__(root, nsmap)
+        super(MainTemplate, self).__init__(root, nsmap)
         self.version = version
-        self.slaves = []
+        self.subordinates = []
 
     def __repr__(self):
         """Return string representation of the template."""
@@ -697,89 +697,89 @@ class MasterTemplate(Template):
 
         An overridable hook method to return the siblings of the root
         element.  This is the root element plus the root elements of
-        all the slave templates.
+        all the subordinate templates.
         """
 
-        return [self.root] + [slave.root for slave in self.slaves]
+        return [self.root] + [subordinate.root for subordinate in self.subordinates]
 
     def _nsmap(self):
         """Hook method for computing the namespace dictionary.
 
         An overridable hook method to return the namespace dictionary.
-        The namespace dictionary is computed by taking the master
+        The namespace dictionary is computed by taking the main
         template's namespace dictionary and updating it from all the
-        slave templates.
+        subordinate templates.
         """
 
         nsmap = self.nsmap.copy()
-        for slave in self.slaves:
-            nsmap.update(slave._nsmap())
+        for subordinate in self.subordinates:
+            nsmap.update(subordinate._nsmap())
         return nsmap
 
-    def attach(self, *slaves):
-        """Attach one or more slave templates.
+    def attach(self, *subordinates):
+        """Attach one or more subordinate templates.
 
-        Attaches one or more slave templates to the master template.
-        Slave templates must have a root element with the same tag as
-        the master template.  The slave template's apply() method will
-        be called to determine if the slave should be applied to this
-        master; if it returns False, that slave will be skipped.
-        (This allows filtering of slaves based on the version of the
-        master template.)
+        Attaches one or more subordinate templates to the main template.
+        Subordinate templates must have a root element with the same tag as
+        the main template.  The subordinate template's apply() method will
+        be called to determine if the subordinate should be applied to this
+        main; if it returns False, that subordinate will be skipped.
+        (This allows filtering of subordinates based on the version of the
+        main template.)
         """
 
-        slave_list = []
-        for slave in slaves:
-            slave = slave.wrap()
+        subordinate_list = []
+        for subordinate in subordinates:
+            subordinate = subordinate.wrap()
 
             # Make sure we have a tree match
-            if slave.root.tag != self.root.tag:
-                slavetag = slave.root.tag
-                mastertag = self.root.tag
-                msg = _("Template tree mismatch; adding slave %(slavetag)s "
-                        "to master %(mastertag)s") % locals()
+            if subordinate.root.tag != self.root.tag:
+                subordinatetag = subordinate.root.tag
+                maintag = self.root.tag
+                msg = _("Template tree mismatch; adding subordinate %(subordinatetag)s "
+                        "to main %(maintag)s") % locals()
                 raise ValueError(msg)
 
-            # Make sure slave applies to this template
-            if not slave.apply(self):
+            # Make sure subordinate applies to this template
+            if not subordinate.apply(self):
                 continue
 
-            slave_list.append(slave)
+            subordinate_list.append(subordinate)
 
-        # Add the slaves
-        self.slaves.extend(slave_list)
+        # Add the subordinates
+        self.subordinates.extend(subordinate_list)
 
     def copy(self):
-        """Return a copy of this master template."""
+        """Return a copy of this main template."""
 
-        # Return a copy of the MasterTemplate
+        # Return a copy of the MainTemplate
         tmp = self.__class__(self.root, self.version, self.nsmap)
-        tmp.slaves = self.slaves[:]
+        tmp.subordinates = self.subordinates[:]
         return tmp
 
 
-class SlaveTemplate(Template):
-    """Represent a slave template.
+class SubordinateTemplate(Template):
+    """Represent a subordinate template.
 
-    Slave templates are versioned derivatives of templates.  Each
-    slave has a minimum version and optional maximum version of the
-    master template to which they can be attached.
+    Subordinate templates are versioned derivatives of templates.  Each
+    subordinate has a minimum version and optional maximum version of the
+    main template to which they can be attached.
     """
 
     def __init__(self, root, min_vers, max_vers=None, nsmap=None):
-        """Initialize a slave template.
+        """Initialize a subordinate template.
 
         :param root: The root element of the template.
-        :param min_vers: The minimum permissible version of the master
-                         template for this slave template to apply.
-        :param max_vers: An optional upper bound for the master
+        :param min_vers: The minimum permissible version of the main
+                         template for this subordinate template to apply.
+        :param max_vers: An optional upper bound for the main
                          template version.
         :param nsmap: An optional namespace dictionary to be
                       associated with the root element of the
                       template.
         """
 
-        super(SlaveTemplate, self).__init__(root, nsmap)
+        super(SubordinateTemplate, self).__init__(root, nsmap)
         self.min_vers = min_vers
         self.max_vers = max_vers
 
@@ -790,23 +790,23 @@ class SlaveTemplate(Template):
                 (self.__class__.__module__, self.__class__.__name__,
                  self.min_vers, self.max_vers, id(self)))
 
-    def apply(self, master):
-        """Hook method for determining slave applicability.
+    def apply(self, main):
+        """Hook method for determining subordinate applicability.
 
         An overridable hook method used to determine if this template
-        is applicable as a slave to a given master template.  This
-        version requires the master template to have a version number
+        is applicable as a subordinate to a given main template.  This
+        version requires the main template to have a version number
         between min_vers and max_vers.
 
-        :param master: The master template to test.
+        :param main: The main template to test.
         """
 
-        # Does the master meet our minimum version requirement?
-        if master.version < self.min_vers:
+        # Does the main meet our minimum version requirement?
+        if main.version < self.min_vers:
             return False
 
         # How about our maximum version requirement?
-        if self.max_vers is not None and master.version > self.max_vers:
+        if self.max_vers is not None and main.version > self.max_vers:
             return False
 
         return True

--- a/nova/compute/manager.py
+++ b/nova/compute/manager.py
@@ -142,7 +142,7 @@ def _get_instances_storage_info():
 
     elif disk.startswith("/dev/dm-"):
         dname = os.path.basename(disk)
-        path = os.path.join("/sys/block/", dname, "slaves")
+        path = os.path.join("/sys/block/", dname, "subordinates")
         for d in os.listdir(path):
             dig_re = re.compile(r'(\d)')
             disk = dig_re.split(d)[0]
@@ -3844,12 +3844,12 @@ class ComputeManager(manager.SchedulerDependentManager):
                 self._set_instance_error_state(context, instance_uuid)
 
     @exception.wrap_exception(notifier=notifier, publisher_id=publisher_id())
-    def add_aggregate_host(self, context, aggregate_id, host, slave_info=None):
+    def add_aggregate_host(self, context, aggregate_id, host, subordinate_info=None):
         """Notify hypervisor of change (for hypervisor pools)."""
         aggregate = self.db.aggregate_get(context, aggregate_id)
         try:
             self.driver.add_to_aggregate(context, aggregate, host,
-                                         slave_info=slave_info)
+                                         subordinate_info=subordinate_info)
         except exception.AggregateError:
             with excutils.save_and_reraise_exception():
                 self.driver.undo_aggregate_operation(context,
@@ -3858,12 +3858,12 @@ class ComputeManager(manager.SchedulerDependentManager):
 
     @exception.wrap_exception(notifier=notifier, publisher_id=publisher_id())
     def remove_aggregate_host(self, context, aggregate_id,
-                              host, slave_info=None):
+                              host, subordinate_info=None):
         """Removes a host from a physical hypervisor pool."""
         aggregate = self.db.aggregate_get(context, aggregate_id)
         try:
             self.driver.remove_from_aggregate(context, aggregate, host,
-                                              slave_info=slave_info)
+                                              subordinate_info=subordinate_info)
         except (exception.AggregateError,
                 exception.InvalidAggregateAction) as e:
             with excutils.save_and_reraise_exception():

--- a/nova/compute/rpcapi.py
+++ b/nova/compute/rpcapi.py
@@ -128,7 +128,7 @@ class ComputeAPI(nova.openstack.common.rpc.proxy.RpcProxy):
 
         2.0 - Remove 1.x backwards compat
         2.1 - Adds orig_sys_metadata to rebuild_instance()
-        2.2 - Adds slave_info parameter to add_aggregate_host() and
+        2.2 - Adds subordinate_info parameter to add_aggregate_host() and
               remove_aggregate_host()
     '''
 
@@ -148,7 +148,7 @@ class ComputeAPI(nova.openstack.common.rpc.proxy.RpcProxy):
                 default_version=self.BASE_RPC_API_VERSION)
 
     def add_aggregate_host(self, ctxt, aggregate_id, host_param, host,
-                           slave_info=None):
+                           subordinate_info=None):
         '''Add aggregate host.
 
         :param ctxt: request context
@@ -160,7 +160,7 @@ class ComputeAPI(nova.openstack.common.rpc.proxy.RpcProxy):
 
         self.cast(ctxt, self.make_msg('add_aggregate_host',
                 aggregate_id=aggregate_id, host=host_param,
-                slave_info=slave_info),
+                subordinate_info=subordinate_info),
                 topic=_compute_topic(self.topic, ctxt, host, None),
                 version='2.2')
 
@@ -390,7 +390,7 @@ class ComputeAPI(nova.openstack.common.rpc.proxy.RpcProxy):
                 _compute_topic(self.topic, ctxt, host, None))
 
     def remove_aggregate_host(self, ctxt, aggregate_id, host_param, host,
-                              slave_info=None):
+                              subordinate_info=None):
         '''Remove aggregate host.
 
         :param ctxt: request context
@@ -402,7 +402,7 @@ class ComputeAPI(nova.openstack.common.rpc.proxy.RpcProxy):
 
         self.cast(ctxt, self.make_msg('remove_aggregate_host',
                 aggregate_id=aggregate_id, host=host_param,
-                slave_info=slave_info),
+                subordinate_info=subordinate_info),
                 topic=_compute_topic(self.topic, ctxt, host, None),
                 version='2.2')
 

--- a/nova/console/xvp.py
+++ b/nova/console/xvp.py
@@ -40,7 +40,7 @@ xvp_opts = [
                help='generated XVP conf file'),
     cfg.StrOpt('console_xvp_pid',
                default='/var/run/xvp.pid',
-               help='XVP master process pid file'),
+               help='XVP main process pid file'),
     cfg.StrOpt('console_xvp_log',
                default='/var/log/xvp.log',
                help='XVP log file'),

--- a/nova/network/ldapdns.py
+++ b/nova/network/ldapdns.py
@@ -35,9 +35,9 @@ ldap_dns_opts = [
     cfg.StrOpt('ldap_dns_password',
                default='password',
                help='password for ldap DNS'),
-    cfg.StrOpt('ldap_dns_soa_hostmaster',
-               default='hostmaster@example.org',
-               help='Hostmaster for ldap dns driver Statement of Authority'),
+    cfg.StrOpt('ldap_dns_soa_hostmain',
+               default='hostmain@example.org',
+               help='Hostmain for ldap dns driver Statement of Authority'),
     cfg.MultiStrOpt('ldap_dns_servers',
                     default=['dns.example.org'],
                     help='DNS Servers for ldap dns driver'),
@@ -144,7 +144,7 @@ class DomainEntry(DNSEntry):
         date = time.strftime('%Y%m%d%H%M%S')
         soa = '%s %s %s %s %s %s %s' % (
                  flags.FLAGS.ldap_dns_servers[0],
-                 flags.FLAGS.ldap_dns_soa_hostmaster,
+                 flags.FLAGS.ldap_dns_soa_hostmain,
                  date,
                  flags.FLAGS.ldap_dns_soa_refresh,
                  flags.FLAGS.ldap_dns_soa_retry,

--- a/nova/network/linux_net.py
+++ b/nova/network/linux_net.py
@@ -2673,7 +2673,7 @@ class LinuxBridgeInterfaceDriver(LinuxNetInterfaceDriver):
                          run_as_root=True)
 
             if (err and err != "device %s is already a member of a bridge;"
-                     "can't enslave it to bridge %s.\n" % (interface, bridge)):
+                     "can't ensubordinate it to bridge %s.\n" % (interface, bridge)):
                 msg = _('Failed to add interface: %s') % err
                 raise exception.NovaException(msg)
 

--- a/nova/tests/api/openstack/test_xmlutil.py
+++ b/nova/tests/api/openstack/test_xmlutil.py
@@ -380,17 +380,17 @@ class TemplateElementTest(test.TestCase):
                      attr2=xmlutil.ConstantSelector(2),
                      attr3=xmlutil.ConstantSelector(3))
 
-        # Create a master template element
-        master_elem = xmlutil.TemplateElement('test', attr1=attrs['attr1'])
+        # Create a main template element
+        main_elem = xmlutil.TemplateElement('test', attr1=attrs['attr1'])
 
-        # Create a couple of slave template element
-        slave_elems = [
+        # Create a couple of subordinate template element
+        subordinate_elems = [
             xmlutil.TemplateElement('test', attr2=attrs['attr2']),
             xmlutil.TemplateElement('test', attr3=attrs['attr3']),
             ]
 
         # Try the render
-        elem = master_elem._render(None, None, slave_elems, None)
+        elem = main_elem._render(None, None, subordinate_elems, None)
 
         # Verify the particulars of the render
         self.assertEqual(elem.tag, 'test')
@@ -402,7 +402,7 @@ class TemplateElementTest(test.TestCase):
         parent = etree.Element('parent')
 
         # Try the render again...
-        elem = master_elem._render(parent, None, slave_elems, dict(a='foo'))
+        elem = main_elem._render(parent, None, subordinate_elems, dict(a='foo'))
 
         # Verify the particulars of the render
         self.assertEqual(len(parent), 1)
@@ -501,46 +501,46 @@ class TemplateTest(test.TestCase):
         self.assertEqual(len(nsmap), 1)
         self.assertEqual(nsmap['a'], 'foo')
 
-    def test_master_attach(self):
-        # Set up a master template
+    def test_main_attach(self):
+        # Set up a main template
         elem = xmlutil.TemplateElement('test')
-        tmpl = xmlutil.MasterTemplate(elem, 1)
+        tmpl = xmlutil.MainTemplate(elem, 1)
 
-        # Make sure it has a root but no slaves
+        # Make sure it has a root but no subordinates
         self.assertEqual(tmpl.root, elem)
-        self.assertEqual(len(tmpl.slaves), 0)
+        self.assertEqual(len(tmpl.subordinates), 0)
 
-        # Try to attach an invalid slave
+        # Try to attach an invalid subordinate
         bad_elem = xmlutil.TemplateElement('test2')
         self.assertRaises(ValueError, tmpl.attach, bad_elem)
-        self.assertEqual(len(tmpl.slaves), 0)
+        self.assertEqual(len(tmpl.subordinates), 0)
 
-        # Try to attach an invalid and a valid slave
+        # Try to attach an invalid and a valid subordinate
         good_elem = xmlutil.TemplateElement('test')
         self.assertRaises(ValueError, tmpl.attach, good_elem, bad_elem)
-        self.assertEqual(len(tmpl.slaves), 0)
+        self.assertEqual(len(tmpl.subordinates), 0)
 
         # Try to attach an inapplicable template
         class InapplicableTemplate(xmlutil.Template):
-            def apply(self, master):
+            def apply(self, main):
                 return False
         inapp_tmpl = InapplicableTemplate(good_elem)
         tmpl.attach(inapp_tmpl)
-        self.assertEqual(len(tmpl.slaves), 0)
+        self.assertEqual(len(tmpl.subordinates), 0)
 
         # Now try attaching an applicable template
         tmpl.attach(good_elem)
-        self.assertEqual(len(tmpl.slaves), 1)
-        self.assertEqual(tmpl.slaves[0].root, good_elem)
+        self.assertEqual(len(tmpl.subordinates), 1)
+        self.assertEqual(tmpl.subordinates[0].root, good_elem)
 
-    def test_master_copy(self):
-        # Construct a master template
+    def test_main_copy(self):
+        # Construct a main template
         elem = xmlutil.TemplateElement('test')
-        tmpl = xmlutil.MasterTemplate(elem, 1, nsmap=dict(a='foo'))
+        tmpl = xmlutil.MainTemplate(elem, 1, nsmap=dict(a='foo'))
 
-        # Give it a slave
-        slave = xmlutil.TemplateElement('test')
-        tmpl.attach(slave)
+        # Give it a subordinate
+        subordinate = xmlutil.TemplateElement('test')
+        tmpl.attach(subordinate)
 
         # Construct a copy
         copy = tmpl.copy()
@@ -550,42 +550,42 @@ class TemplateTest(test.TestCase):
         self.assertEqual(tmpl.root, copy.root)
         self.assertEqual(tmpl.version, copy.version)
         self.assertEqual(id(tmpl.nsmap), id(copy.nsmap))
-        self.assertNotEqual(id(tmpl.slaves), id(copy.slaves))
-        self.assertEqual(len(tmpl.slaves), len(copy.slaves))
-        self.assertEqual(tmpl.slaves[0], copy.slaves[0])
+        self.assertNotEqual(id(tmpl.subordinates), id(copy.subordinates))
+        self.assertEqual(len(tmpl.subordinates), len(copy.subordinates))
+        self.assertEqual(tmpl.subordinates[0], copy.subordinates[0])
 
-    def test_slave_apply(self):
-        # Construct a master template
+    def test_subordinate_apply(self):
+        # Construct a main template
         elem = xmlutil.TemplateElement('test')
-        master = xmlutil.MasterTemplate(elem, 3)
+        main = xmlutil.MainTemplate(elem, 3)
 
-        # Construct a slave template with applicable minimum version
-        slave = xmlutil.SlaveTemplate(elem, 2)
-        self.assertEqual(slave.apply(master), True)
+        # Construct a subordinate template with applicable minimum version
+        subordinate = xmlutil.SubordinateTemplate(elem, 2)
+        self.assertEqual(subordinate.apply(main), True)
 
-        # Construct a slave template with equal minimum version
-        slave = xmlutil.SlaveTemplate(elem, 3)
-        self.assertEqual(slave.apply(master), True)
+        # Construct a subordinate template with equal minimum version
+        subordinate = xmlutil.SubordinateTemplate(elem, 3)
+        self.assertEqual(subordinate.apply(main), True)
 
-        # Construct a slave template with inapplicable minimum version
-        slave = xmlutil.SlaveTemplate(elem, 4)
-        self.assertEqual(slave.apply(master), False)
+        # Construct a subordinate template with inapplicable minimum version
+        subordinate = xmlutil.SubordinateTemplate(elem, 4)
+        self.assertEqual(subordinate.apply(main), False)
 
-        # Construct a slave template with applicable version range
-        slave = xmlutil.SlaveTemplate(elem, 2, 4)
-        self.assertEqual(slave.apply(master), True)
+        # Construct a subordinate template with applicable version range
+        subordinate = xmlutil.SubordinateTemplate(elem, 2, 4)
+        self.assertEqual(subordinate.apply(main), True)
 
-        # Construct a slave template with low version range
-        slave = xmlutil.SlaveTemplate(elem, 1, 2)
-        self.assertEqual(slave.apply(master), False)
+        # Construct a subordinate template with low version range
+        subordinate = xmlutil.SubordinateTemplate(elem, 1, 2)
+        self.assertEqual(subordinate.apply(main), False)
 
-        # Construct a slave template with high version range
-        slave = xmlutil.SlaveTemplate(elem, 4, 5)
-        self.assertEqual(slave.apply(master), False)
+        # Construct a subordinate template with high version range
+        subordinate = xmlutil.SubordinateTemplate(elem, 4, 5)
+        self.assertEqual(subordinate.apply(main), False)
 
-        # Construct a slave template with matching version range
-        slave = xmlutil.SlaveTemplate(elem, 3, 3)
-        self.assertEqual(slave.apply(master), True)
+        # Construct a subordinate template with matching version range
+        subordinate = xmlutil.SubordinateTemplate(elem, 3, 3)
+        self.assertEqual(subordinate.apply(main), True)
 
     def test__serialize(self):
         # Our test object to serialize
@@ -606,7 +606,7 @@ class TemplateTest(test.TestCase):
                 },
             }
 
-        # Set up our master template
+        # Set up our main template
         root = xmlutil.TemplateElement('test', selector='test',
                                        name='name')
         value = xmlutil.SubTemplateElement(root, 'value', selector='values')
@@ -614,22 +614,22 @@ class TemplateTest(test.TestCase):
         attrs = xmlutil.SubTemplateElement(root, 'attrs', selector='attrs')
         xmlutil.SubTemplateElement(attrs, 'attr', selector=xmlutil.get_items,
                                    key=0, value=1)
-        master = xmlutil.MasterTemplate(root, 1, nsmap=dict(f='foo'))
+        main = xmlutil.MainTemplate(root, 1, nsmap=dict(f='foo'))
 
-        # Set up our slave template
-        root_slave = xmlutil.TemplateElement('test', selector='test')
-        image = xmlutil.SubTemplateElement(root_slave, 'image',
+        # Set up our subordinate template
+        root_subordinate = xmlutil.TemplateElement('test', selector='test')
+        image = xmlutil.SubTemplateElement(root_subordinate, 'image',
                                            selector='image', id='id')
         image.text = xmlutil.Selector('name')
-        slave = xmlutil.SlaveTemplate(root_slave, 1, nsmap=dict(b='bar'))
+        subordinate = xmlutil.SubordinateTemplate(root_subordinate, 1, nsmap=dict(b='bar'))
 
-        # Attach the slave to the master...
-        master.attach(slave)
+        # Attach the subordinate to the main...
+        main.attach(subordinate)
 
         # Try serializing our object
-        siblings = master._siblings()
-        nsmap = master._nsmap()
-        result = master._serialize(None, obj, siblings, nsmap)
+        siblings = main._siblings()
+        nsmap = main._nsmap()
+        result = main._serialize(None, obj, siblings, nsmap)
 
         # Now we get to manually walk the element tree...
         self.assertEqual(result.tag, 'test')
@@ -653,60 +653,60 @@ class TemplateTest(test.TestCase):
         self.assertEqual(result[idx].text, obj['test']['image']['name'])
 
 
-class MasterTemplateBuilder(xmlutil.TemplateBuilder):
+class MainTemplateBuilder(xmlutil.TemplateBuilder):
     def construct(self):
         elem = xmlutil.TemplateElement('test')
-        return xmlutil.MasterTemplate(elem, 1)
+        return xmlutil.MainTemplate(elem, 1)
 
 
-class SlaveTemplateBuilder(xmlutil.TemplateBuilder):
+class SubordinateTemplateBuilder(xmlutil.TemplateBuilder):
     def construct(self):
         elem = xmlutil.TemplateElement('test')
-        return xmlutil.SlaveTemplate(elem, 1)
+        return xmlutil.SubordinateTemplate(elem, 1)
 
 
 class TemplateBuilderTest(test.TestCase):
-    def test_master_template_builder(self):
+    def test_main_template_builder(self):
         # Make sure the template hasn't been built yet
-        self.assertEqual(MasterTemplateBuilder._tmpl, None)
+        self.assertEqual(MainTemplateBuilder._tmpl, None)
 
         # Now, construct the template
-        tmpl1 = MasterTemplateBuilder()
+        tmpl1 = MainTemplateBuilder()
 
         # Make sure that there is a template cached...
-        self.assertNotEqual(MasterTemplateBuilder._tmpl, None)
+        self.assertNotEqual(MainTemplateBuilder._tmpl, None)
 
         # Make sure it wasn't what was returned...
-        self.assertNotEqual(MasterTemplateBuilder._tmpl, tmpl1)
+        self.assertNotEqual(MainTemplateBuilder._tmpl, tmpl1)
 
         # Make sure it doesn't get rebuilt
-        cached = MasterTemplateBuilder._tmpl
-        tmpl2 = MasterTemplateBuilder()
-        self.assertEqual(MasterTemplateBuilder._tmpl, cached)
+        cached = MainTemplateBuilder._tmpl
+        tmpl2 = MainTemplateBuilder()
+        self.assertEqual(MainTemplateBuilder._tmpl, cached)
 
         # Make sure we're always getting fresh copies
         self.assertNotEqual(tmpl1, tmpl2)
 
         # Make sure we can override the copying behavior
-        tmpl3 = MasterTemplateBuilder(False)
-        self.assertEqual(MasterTemplateBuilder._tmpl, tmpl3)
+        tmpl3 = MainTemplateBuilder(False)
+        self.assertEqual(MainTemplateBuilder._tmpl, tmpl3)
 
-    def test_slave_template_builder(self):
+    def test_subordinate_template_builder(self):
         # Make sure the template hasn't been built yet
-        self.assertEqual(SlaveTemplateBuilder._tmpl, None)
+        self.assertEqual(SubordinateTemplateBuilder._tmpl, None)
 
         # Now, construct the template
-        tmpl1 = SlaveTemplateBuilder()
+        tmpl1 = SubordinateTemplateBuilder()
 
         # Make sure there is a template cached...
-        self.assertNotEqual(SlaveTemplateBuilder._tmpl, None)
+        self.assertNotEqual(SubordinateTemplateBuilder._tmpl, None)
 
         # Make sure it was what was returned...
-        self.assertEqual(SlaveTemplateBuilder._tmpl, tmpl1)
+        self.assertEqual(SubordinateTemplateBuilder._tmpl, tmpl1)
 
         # Make sure it doesn't get rebuilt
-        tmpl2 = SlaveTemplateBuilder()
-        self.assertEqual(SlaveTemplateBuilder._tmpl, tmpl1)
+        tmpl2 = SubordinateTemplateBuilder()
+        self.assertEqual(SubordinateTemplateBuilder._tmpl, tmpl1)
 
         # Make sure we're always getting the cached copy
         self.assertEqual(tmpl1, tmpl2)
@@ -717,6 +717,6 @@ class MiscellaneousXMLUtilTests(test.TestCase):
         expected_xml = ("<?xml version='1.0' encoding='UTF-8'?>\n"
                         '<wrapper><a>foo</a><b>bar</b></wrapper>')
         root = xmlutil.make_flat_dict('wrapper')
-        tmpl = xmlutil.MasterTemplate(root, 1)
+        tmpl = xmlutil.MainTemplate(root, 1)
         result = tmpl.serialize(dict(wrapper=dict(a='foo', b='bar')))
         self.assertEqual(result, expected_xml)

--- a/nova/tests/compute/test_compute.py
+++ b/nova/tests/compute/test_compute.py
@@ -5758,31 +5758,31 @@ class ComputeAggrTestCase(BaseTestCase):
         self.compute.remove_aggregate_host(self.context, self.aggr.id, "host")
         self.assertTrue(fake_driver_remove_from_aggregate.called)
 
-    def test_add_aggregate_host_passes_slave_info_to_driver(self):
+    def test_add_aggregate_host_passes_subordinate_info_to_driver(self):
         def driver_add_to_aggregate(context, aggregate, host, **kwargs):
             self.assertEquals(self.context, context)
             self.assertEquals(aggregate.id, self.aggr.id)
             self.assertEquals(host, "the_host")
-            self.assertEquals("SLAVE_INFO", kwargs.get("slave_info"))
+            self.assertEquals("SLAVE_INFO", kwargs.get("subordinate_info"))
 
         self.stubs.Set(self.compute.driver, "add_to_aggregate",
                        driver_add_to_aggregate)
 
         self.compute.add_aggregate_host(self.context, self.aggr.id,
-            "the_host", slave_info="SLAVE_INFO")
+            "the_host", subordinate_info="SLAVE_INFO")
 
-    def test_remove_from_aggregate_passes_slave_info_to_driver(self):
+    def test_remove_from_aggregate_passes_subordinate_info_to_driver(self):
         def driver_remove_from_aggregate(context, aggregate, host, **kwargs):
             self.assertEquals(self.context, context)
             self.assertEquals(aggregate.id, self.aggr.id)
             self.assertEquals(host, "the_host")
-            self.assertEquals("SLAVE_INFO", kwargs.get("slave_info"))
+            self.assertEquals("SLAVE_INFO", kwargs.get("subordinate_info"))
 
         self.stubs.Set(self.compute.driver, "remove_from_aggregate",
                        driver_remove_from_aggregate)
 
         self.compute.remove_aggregate_host(self.context,
-            self.aggr.id, "the_host", slave_info="SLAVE_INFO")
+            self.aggr.id, "the_host", subordinate_info="SLAVE_INFO")
 
 
 class ComputePolicyTestCase(BaseTestCase):

--- a/nova/tests/compute/test_rpcapi.py
+++ b/nova/tests/compute/test_rpcapi.py
@@ -99,7 +99,7 @@ class ComputeRpcAPITestCase(test.TestCase):
 
     def test_add_aggregate_host(self):
         self._test_compute_api('add_aggregate_host', 'cast', aggregate_id='id',
-                host_param='host', host='host', slave_info={}, version='2.2')
+                host_param='host', host='host', subordinate_info={}, version='2.2')
 
     def test_add_fixed_ip_to_instance(self):
         self._test_compute_api('add_fixed_ip_to_instance', 'cast',
@@ -250,7 +250,7 @@ class ComputeRpcAPITestCase(test.TestCase):
     def test_remove_aggregate_host(self):
         self._test_compute_api('remove_aggregate_host', 'cast',
                 aggregate_id='id', host_param='host', host='host',
-                slave_info={}, version='2.2')
+                subordinate_info={}, version='2.2')
 
     def test_remove_fixed_ip_from_instance(self):
         self._test_compute_api('remove_fixed_ip_from_instance', 'cast',

--- a/nova/tests/test_xenapi.py
+++ b/nova/tests/test_xenapi.py
@@ -1837,7 +1837,7 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
                   'metadata': {pool_states.POOL_FLAG: 'XenAPI'}}
         self.aggr = db.aggregate_create(self.context, values)
         self.fake_metadata = {pool_states.POOL_FLAG: 'XenAPI',
-                              'master_compute': 'host',
+                              'main_compute': 'host',
                               pool_states.KEY: pool_states.ACTIVE,
                               'host': xenapi_fake.get_record('host',
                                                              host_ref)['uuid']}
@@ -1846,18 +1846,18 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
 
         calls = []
 
-        def pool_add_to_aggregate(context, aggregate, host, slave_info=None):
+        def pool_add_to_aggregate(context, aggregate, host, subordinate_info=None):
             self.assertEquals("CONTEXT", context)
             self.assertEquals("AGGREGATE", aggregate)
             self.assertEquals("HOST", host)
-            self.assertEquals("SLAVEINFO", slave_info)
+            self.assertEquals("SLAVEINFO", subordinate_info)
             calls.append(pool_add_to_aggregate)
         self.stubs.Set(self.conn._pool,
                        "add_to_aggregate",
                        pool_add_to_aggregate)
 
         self.conn.add_to_aggregate("CONTEXT", "AGGREGATE", "HOST",
-                                   slave_info="SLAVEINFO")
+                                   subordinate_info="SLAVEINFO")
 
         self.assertTrue(pool_add_to_aggregate in calls)
 
@@ -1866,18 +1866,18 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
         calls = []
 
         def pool_remove_from_aggregate(context, aggregate, host,
-                                       slave_info=None):
+                                       subordinate_info=None):
             self.assertEquals("CONTEXT", context)
             self.assertEquals("AGGREGATE", aggregate)
             self.assertEquals("HOST", host)
-            self.assertEquals("SLAVEINFO", slave_info)
+            self.assertEquals("SLAVEINFO", subordinate_info)
             calls.append(pool_remove_from_aggregate)
         self.stubs.Set(self.conn._pool,
                        "remove_from_aggregate",
                        pool_remove_from_aggregate)
 
         self.conn.remove_from_aggregate("CONTEXT", "AGGREGATE", "HOST",
-                                        slave_info="SLAVEINFO")
+                                        subordinate_info="SLAVEINFO")
 
         self.assertTrue(pool_remove_from_aggregate in calls)
 
@@ -1893,11 +1893,11 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
         self.assertThat(self.fake_metadata,
                         matchers.DictMatches(result.metadetails))
 
-    def test_join_slave(self):
-        """Ensure join_slave gets called when the request gets to master."""
-        def fake_join_slave(id, compute_uuid, host, url, user, password):
-            fake_join_slave.called = True
-        self.stubs.Set(self.conn._pool, "_join_slave", fake_join_slave)
+    def test_join_subordinate(self):
+        """Ensure join_subordinate gets called when the request gets to main."""
+        def fake_join_subordinate(id, compute_uuid, host, url, user, password):
+            fake_join_subordinate.called = True
+        self.stubs.Set(self.conn._pool, "_join_subordinate", fake_join_subordinate)
 
         aggregate = self._aggregate_setup(hosts=['host', 'host2'],
                                           metadata=self.fake_metadata)
@@ -1907,7 +1907,7 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
                                          user='fake_user',
                                          passwd='fake_pass',
                                          xenhost_uuid='fake_uuid'))
-        self.assertTrue(fake_join_slave.called)
+        self.assertTrue(fake_join_subordinate.called)
 
     def test_add_to_aggregate_first_host(self):
         def fake_pool_set_name_label(self, session, pool_ref, name):
@@ -1947,19 +1947,19 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
                           self.conn._pool.remove_from_aggregate,
                           self.context, result, "test_host")
 
-    def test_remove_slave(self):
-        """Ensure eject slave gets called."""
-        def fake_eject_slave(id, compute_uuid, host_uuid):
-            fake_eject_slave.called = True
-        self.stubs.Set(self.conn._pool, "_eject_slave", fake_eject_slave)
+    def test_remove_subordinate(self):
+        """Ensure eject subordinate gets called."""
+        def fake_eject_subordinate(id, compute_uuid, host_uuid):
+            fake_eject_subordinate.called = True
+        self.stubs.Set(self.conn._pool, "_eject_subordinate", fake_eject_subordinate)
 
         self.fake_metadata['host2'] = 'fake_host2_uuid'
         aggregate = self._aggregate_setup(hosts=['host', 'host2'],
                 metadata=self.fake_metadata, aggr_state=pool_states.ACTIVE)
         self.conn._pool.remove_from_aggregate(self.context, aggregate, "host2")
-        self.assertTrue(fake_eject_slave.called)
+        self.assertTrue(fake_eject_subordinate.called)
 
-    def test_remove_master_solo(self):
+    def test_remove_main_solo(self):
         """Ensure metadata are cleared after removal."""
         def fake_clear_pool(id):
             fake_clear_pool.called = True
@@ -1973,8 +1973,8 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
                 pool_states.KEY: pool_states.ACTIVE},
                 matchers.DictMatches(result.metadetails))
 
-    def test_remote_master_non_empty_pool(self):
-        """Ensure AggregateError is raised if removing the master."""
+    def test_remote_main_non_empty_pool(self):
+        """Ensure AggregateError is raised if removing the main."""
         aggregate = self._aggregate_setup(hosts=['host', 'host2'],
                                           metadata=self.fake_metadata)
 
@@ -2092,16 +2092,16 @@ class MockComputeAPI(object):
         self._mock_calls = []
 
     def add_aggregate_host(self, ctxt, aggregate_id,
-                                     host_param, host, slave_info):
+                                     host_param, host, subordinate_info):
         self._mock_calls.append((
             self.add_aggregate_host, ctxt, aggregate_id,
-            host_param, host, slave_info))
+            host_param, host, subordinate_info))
 
     def remove_aggregate_host(self, ctxt, aggregate_id, host_param,
-                              host, slave_info):
+                              host, subordinate_info):
         self._mock_calls.append((
             self.remove_aggregate_host, ctxt, aggregate_id,
-            host_param, host, slave_info))
+            host_param, host, subordinate_info))
 
 
 class StubDependencies(object):
@@ -2116,10 +2116,10 @@ class StubDependencies(object):
     def _get_metadata(self, *_ignore):
         return {
             pool_states.KEY: {},
-            'master_compute': 'master'
+            'main_compute': 'main'
         }
 
-    def _create_slave_info(self, *ignore):
+    def _create_subordinate_info(self, *ignore):
         return "SLAVE_INFO"
 
 
@@ -2129,27 +2129,27 @@ class ResourcePoolWithStubs(StubDependencies, pool.ResourcePool):
 
 class HypervisorPoolTestCase(test.TestCase):
 
-    def test_slave_asks_master_to_add_slave_to_pool(self):
-        slave = ResourcePoolWithStubs()
+    def test_subordinate_asks_main_to_add_subordinate_to_pool(self):
+        subordinate = ResourcePoolWithStubs()
         aggregate = Aggregate(id=98, hosts=[])
 
-        slave.add_to_aggregate("CONTEXT", aggregate, "slave")
+        subordinate.add_to_aggregate("CONTEXT", aggregate, "subordinate")
 
         self.assertIn(
-            (slave.compute_rpcapi.add_aggregate_host,
-            "CONTEXT", 98, "slave", "master", "SLAVE_INFO"),
-            slave.compute_rpcapi._mock_calls)
+            (subordinate.compute_rpcapi.add_aggregate_host,
+            "CONTEXT", 98, "subordinate", "main", "SLAVE_INFO"),
+            subordinate.compute_rpcapi._mock_calls)
 
-    def test_slave_asks_master_to_remove_slave_from_pool(self):
-        slave = ResourcePoolWithStubs()
+    def test_subordinate_asks_main_to_remove_subordinate_from_pool(self):
+        subordinate = ResourcePoolWithStubs()
         aggregate = Aggregate(id=98, hosts=[])
 
-        slave.remove_from_aggregate("CONTEXT", aggregate, "slave")
+        subordinate.remove_from_aggregate("CONTEXT", aggregate, "subordinate")
 
         self.assertIn(
-            (slave.compute_rpcapi.remove_aggregate_host,
-            "CONTEXT", 98, "slave", "master", "SLAVE_INFO"),
-            slave.compute_rpcapi._mock_calls)
+            (subordinate.compute_rpcapi.remove_aggregate_host,
+            "CONTEXT", 98, "subordinate", "main", "SLAVE_INFO"),
+            subordinate.compute_rpcapi._mock_calls)
 
 
 class SwapXapiHostTestCase(test.TestCase):

--- a/nova/virt/xenapi/fake.py
+++ b/nova/virt/xenapi/fake.py
@@ -685,7 +685,7 @@ class SessionBase(object):
             return self._session
         elif name == 'xenapi':
             return _Dispatcher(self.xenapi_request, None)
-        elif name.startswith('login') or name.startswith('slave_local'):
+        elif name.startswith('login') or name.startswith('subordinate_local'):
             return lambda *params: self._login(name, params)
         elif name.startswith('Async'):
             return lambda *params: self._async(name, params)

--- a/nova/virt/xenapi/pool.py
+++ b/nova/virt/xenapi/pool.py
@@ -75,7 +75,7 @@ class ResourcePool(object):
             LOG.exception(_('Aggregate %(aggregate_id)s: unrecoverable state '
                             'during operation on %(host)s') % locals())
 
-    def add_to_aggregate(self, context, aggregate, host, slave_info=None):
+    def add_to_aggregate(self, context, aggregate, host, subordinate_info=None):
         """Add a compute host to an aggregate."""
         if not self._is_hv_pool(context, aggregate.id):
             return
@@ -98,39 +98,39 @@ class ResourcePool(object):
             db.aggregate_metadata_add(context, aggregate.id,
                     {pool_states.KEY: pool_states.CHANGING})
         if len(aggregate.hosts) == 1:
-            # this is the first host of the pool -> make it master
+            # this is the first host of the pool -> make it main
             self._init_pool(aggregate.id, aggregate.name)
-            # save metadata so that we can find the master again
-            metadata = {'master_compute': host,
+            # save metadata so that we can find the main again
+            metadata = {'main_compute': host,
                         host: self._host_uuid,
                         pool_states.KEY: pool_states.ACTIVE}
             db.aggregate_metadata_add(context, aggregate.id, metadata)
         else:
             # the pool is already up and running, we need to figure out
             # whether we can serve the request from this host or not.
-            master_compute = self._get_metadata(context,
-                    aggregate.id)['master_compute']
-            if master_compute == FLAGS.host and master_compute != host:
-                # this is the master ->  do a pool-join
-                # To this aim, nova compute on the slave has to go down.
+            main_compute = self._get_metadata(context,
+                    aggregate.id)['main_compute']
+            if main_compute == FLAGS.host and main_compute != host:
+                # this is the main ->  do a pool-join
+                # To this aim, nova compute on the subordinate has to go down.
                 # NOTE: it is assumed that ONLY nova compute is running now
-                self._join_slave(aggregate.id, host,
-                                 slave_info.get('compute_uuid'),
-                                 slave_info.get('url'), slave_info.get('user'),
-                                 slave_info.get('passwd'))
-                metadata = {host: slave_info.get('xenhost_uuid'), }
+                self._join_subordinate(aggregate.id, host,
+                                 subordinate_info.get('compute_uuid'),
+                                 subordinate_info.get('url'), subordinate_info.get('user'),
+                                 subordinate_info.get('passwd'))
+                metadata = {host: subordinate_info.get('xenhost_uuid'), }
                 db.aggregate_metadata_add(context, aggregate.id, metadata)
-            elif master_compute and master_compute != host:
-                # send rpc cast to master, asking to add the following
+            elif main_compute and main_compute != host:
+                # send rpc cast to main, asking to add the following
                 # host with specified credentials.
-                slave_info = self._create_slave_info()
+                subordinate_info = self._create_subordinate_info()
 
                 self.compute_rpcapi.add_aggregate_host(
-                    context, aggregate.id, host, master_compute, slave_info)
+                    context, aggregate.id, host, main_compute, subordinate_info)
 
-    def remove_from_aggregate(self, context, aggregate, host, slave_info=None):
+    def remove_from_aggregate(self, context, aggregate, host, subordinate_info=None):
         """Remove a compute host from an aggregate."""
-        slave_info = slave_info or dict()
+        subordinate_info = subordinate_info or dict()
         if not self._is_hv_pool(context, aggregate.id):
             return
 
@@ -145,20 +145,20 @@ class ResourcePool(object):
                     reason=invalid[self._get_metadata(context,
                             aggregate.id)[pool_states.KEY]])
 
-        master_compute = self._get_metadata(context,
-                aggregate.id)['master_compute']
-        if master_compute == FLAGS.host and master_compute != host:
-            # this is the master -> instruct it to eject a host from the pool
+        main_compute = self._get_metadata(context,
+                aggregate.id)['main_compute']
+        if main_compute == FLAGS.host and main_compute != host:
+            # this is the main -> instruct it to eject a host from the pool
             host_uuid = self._get_metadata(context, aggregate.id)[host]
-            self._eject_slave(aggregate.id,
-                              slave_info.get('compute_uuid'), host_uuid)
+            self._eject_subordinate(aggregate.id,
+                              subordinate_info.get('compute_uuid'), host_uuid)
             db.aggregate_metadata_delete(context, aggregate.id, host)
-        elif master_compute == host:
-            # Remove master from its own pool -> destroy pool only if the
-            # master is on its own, otherwise raise fault. Destroying a
-            # pool made only by master is fictional
+        elif main_compute == host:
+            # Remove main from its own pool -> destroy pool only if the
+            # main is on its own, otherwise raise fault. Destroying a
+            # pool made only by main is fictional
             if len(aggregate.hosts) > 1:
-                # NOTE: this could be avoided by doing a master
+                # NOTE: this could be avoided by doing a main
                 # re-election, but this is simpler for now.
                 raise exception.InvalidAggregateAction(
                                     aggregate_id=aggregate.id,
@@ -167,33 +167,33 @@ class ResourcePool(object):
                                              'from the pool; pool not empty')
                                              % locals())
             self._clear_pool(aggregate.id)
-            for key in ['master_compute', host]:
+            for key in ['main_compute', host]:
                 db.aggregate_metadata_delete(context, aggregate.id, key)
-        elif master_compute and master_compute != host:
-            # A master exists -> forward pool-eject request to master
-            slave_info = self._create_slave_info()
+        elif main_compute and main_compute != host:
+            # A main exists -> forward pool-eject request to main
+            subordinate_info = self._create_subordinate_info()
 
             self.compute_rpcapi.remove_aggregate_host(
-                context, aggregate.id, host, master_compute, slave_info)
+                context, aggregate.id, host, main_compute, subordinate_info)
         else:
             # this shouldn't have happened
             raise exception.AggregateError(aggregate_id=aggregate.id,
                                            action='remove_from_aggregate',
                                            reason=_('Unable to eject %(host)s '
-                                           'from the pool; No master found')
+                                           'from the pool; No main found')
                                            % locals())
 
-    def _join_slave(self, aggregate_id, host, compute_uuid, url, user, passwd):
-        """Joins a slave into a XenServer resource pool."""
+    def _join_subordinate(self, aggregate_id, host, compute_uuid, url, user, passwd):
+        """Joins a subordinate into a XenServer resource pool."""
         try:
             args = {'compute_uuid': compute_uuid,
                     'url': url,
                     'user': user,
                     'password': passwd,
                     'force': jsonutils.dumps(FLAGS.use_join_force),
-                    'master_addr': self._host_addr,
-                    'master_user': FLAGS.xenapi_connection_username,
-                    'master_pass': FLAGS.xenapi_connection_password, }
+                    'main_addr': self._host_addr,
+                    'main_user': FLAGS.xenapi_connection_username,
+                    'main_pass': FLAGS.xenapi_connection_password, }
             self._session.call_plugin('xenhost', 'host_join', args)
         except self._session.XenAPI.Failure as e:
             LOG.error(_("Pool-Join failed: %(e)s") % locals())
@@ -202,8 +202,8 @@ class ResourcePool(object):
                                            reason=_('Unable to join %(host)s '
                                                   'in the pool') % locals())
 
-    def _eject_slave(self, aggregate_id, compute_uuid, host_uuid):
-        """Eject a slave from a XenServer resource pool."""
+    def _eject_subordinate(self, aggregate_id, compute_uuid, host_uuid):
+        """Eject a subordinate from a XenServer resource pool."""
         try:
             # shutdown nova-compute; if there are other VMs running, e.g.
             # guest instances, the eject will fail. That's a precaution
@@ -243,7 +243,7 @@ class ResourcePool(object):
                                            action='remove_from_aggregate',
                                            reason=str(e.details))
 
-    def _create_slave_info(self):
+    def _create_subordinate_info(self):
         """XenServer specific info needed to join the hypervisor pool"""
         # replace the address from the xenapi connection url
         # because this might be 169.254.0.1, i.e. xenapi

--- a/nova/virt/xenapi/pool_states.py
+++ b/nova/virt/xenapi/pool_states.py
@@ -27,7 +27,7 @@ cases.
 A 'created' pool becomes 'changing' during the first request of
 adding a host. During a 'changing' status no other requests will be accepted;
 this is to allow the hypervisor layer to instantiate the underlying pool
-without any potential race condition that may incur in master/slave-based
+without any potential race condition that may incur in main/subordinate-based
 configurations. The pool goes into the 'active' state when the underlying
 pool has been correctly instantiated.
 All other operations (e.g. add/remove hosts) that succeed will keep the

--- a/tools/db/schema_diff.py
+++ b/tools/db/schema_diff.py
@@ -29,7 +29,7 @@ The schema versions are specified by providing a git ref (a branch name or
 commit hash) and a SQLAlchemy-Migrate version number:
 Run like:
 
-    ./tools/db/schema_diff.py mysql master:latest my_branch:82
+    ./tools/db/schema_diff.py mysql main:latest my_branch:82
 """
 import datetime
 import glob
@@ -214,12 +214,12 @@ def parse_options():
     try:
         orig_branch, orig_version = sys.argv[2].split(':')
     except IndexError:
-        usage('original branch and version required (e.g. master:82)')
+        usage('original branch and version required (e.g. main:82)')
 
     try:
         new_branch, new_version = sys.argv[3].split(':')
     except IndexError:
-        usage('new branch and version required (e.g. master:82)')
+        usage('new branch and version required (e.g. main:82)')
 
     return db_type, orig_branch, orig_version, new_branch, new_version
 

--- a/tools/hacking.py
+++ b/tools/hacking.py
@@ -442,7 +442,7 @@ def once_git_check_commit_title():
         raise Exception("git log failed with code %s" % subp.returncode)
 
     #From https://github.com/openstack/openstack-ci-puppet
-    #       /blob/master/modules/gerrit/manifests/init.pp#L74
+    #       /blob/main/modules/gerrit/manifests/init.pp#L74
     #Changeid|bug|blueprint
     git_keywords = (r'(I[0-9a-f]{8,40})|'
                     '([Bb]ug|[Ll][Pp])[\s\#:]*(\d+)|'


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.